### PR TITLE
[Merged by Bors] - Fix Unicode Line Splitting

### DIFF
--- a/crates/bevy_retro_text/src/systems.rs
+++ b/crates/bevy_retro_text/src/systems.rs
@@ -101,7 +101,7 @@ pub fn rasterize_text_block(
     // Start glyph layout
     let mut current_line = Vec::new();
     let mut line_x = 0; // The x position in the line we are currently at
-    for (char_i, char) in text.text.chars().enumerate() {
+    for (char_i, char) in text.text.char_indices() {
         // Get the glyph for this character
         let glyph = font
             .glyphs()


### PR DESCRIPTION
Use byte indices instead of char indices when evaluating break points
in text.